### PR TITLE
Add Valkey support for OpenShift deployments

### DIFF
--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -36,10 +36,6 @@ jobs:
         echo "Running template validation..."
         helm template ros-ocp-test . --debug --dry-run
         echo "✓ Helm template validation completed successfully"
-        
-        # Additional template checks
-        echo "Checking template output for common issues..."
-        helm template ros-ocp-test . | grep -E "(apiVersion|kind|metadata)" | head -10
-        echo "✓ Template structure validation completed"
+
 
 

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -32,9 +32,14 @@ jobs:
         echo "=== Validating Helm templates ==="
         cd ros-ocp
 
-        # Template with strict validation
-        echo "Running strict template validation..."
-        helm template ros-ocp-test . --validate
+        # Template validation without cluster connection
+        echo "Running template validation..."
+        helm template ros-ocp-test . --debug --dry-run
         echo "✓ Helm template validation completed successfully"
+        
+        # Additional template checks
+        echo "Checking template output for common issues..."
+        helm template ros-ocp-test . | grep -E "(apiVersion|kind|metadata)" | head -10
+        echo "✓ Template structure validation completed"
 
 

--- a/.github/workflows/lint-and-validate.yml
+++ b/.github/workflows/lint-and-validate.yml
@@ -5,8 +5,7 @@ on:
     branches: [ main, master ]
     paths:
       - 'ros-ocp/**'
-
-workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   helm-validation:

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -125,32 +125,58 @@ jobs:
           echo "Waiting for services to stabilize..."
           sleep 60
 
-          # Verify authentication setup was created by deploy-kind.sh
-          if [ -f "/tmp/dev-kubeconfig" ]; then
-            echo "✅ Authentication kubeconfig found at /tmp/dev-kubeconfig"
-          else
-            echo "❌ Authentication kubeconfig not found"
-            echo "Expected file: /tmp/dev-kubeconfig"
-            echo "This should have been created by deploy-kind.sh"
-            ls -la /tmp/ | grep -E "(kubeconfig|auth)" || true
-          fi
-
+          # Kubernetes authentication verification (1.24+ compatible)
+          echo "=== Kubernetes Authentication Setup ==="
+          
           # Check if service account exists
           if kubectl get serviceaccount insights-ros-ingress -n ${{ env.NAMESPACE }} >/dev/null 2>&1; then
             echo "✅ insights-ros-ingress service account found"
-
-            # Check if token secret exists
-            if kubectl get secret insights-ros-ingress-token -n ${{ env.NAMESPACE }} >/dev/null 2>&1; then
-              echo "✅ insights-ros-ingress-token secret found"
+            
+            # Create service account token using modern TokenRequest API (Kubernetes 1.24+)
+            echo "Creating service account token using TokenRequest API..."
+            if TOKEN=$(kubectl create token insights-ros-ingress -n ${{ env.NAMESPACE }} --duration=3600s 2>/dev/null); then
+              if [ -n "$TOKEN" ] && [ ${#TOKEN} -gt 50 ]; then
+                echo "✅ Service account token created successfully (length: ${#TOKEN})"
+                echo "✅ Modern Kubernetes authentication is working"
+                
+                # Test token validation
+                if kubectl auth can-i get pods --as=system:serviceaccount:${{ env.NAMESPACE }}:insights-ros-ingress -n ${{ env.NAMESPACE }} >/dev/null 2>&1; then
+                  echo "✅ Service account has proper RBAC permissions"
+                else
+                  echo "⚠️  Service account may have limited RBAC permissions (this is normal for testing)"
+                fi
+              else
+                echo "❌ Service account token is invalid or too short"
+                exit 1
+              fi
             else
-              echo "❌ insights-ros-ingress-token secret not found"
-              kubectl get secrets -n ${{ env.NAMESPACE }} | head -10 || true
+              echo "❌ Failed to create service account token"
+              echo "This may indicate RBAC or API server issues"
+              exit 1
             fi
           else
             echo "❌ insights-ros-ingress service account not found"
+            echo "Available service accounts:"
             kubectl get serviceaccounts -n ${{ env.NAMESPACE }} || true
+            exit 1
           fi
 
+          # Legacy authentication check (for reference, but not required)
+          echo "=== Legacy Authentication Check (for reference) ==="
+          if [ -f "/tmp/dev-kubeconfig" ]; then
+            echo "ℹ️  Legacy kubeconfig found at /tmp/dev-kubeconfig"
+          else
+            echo "ℹ️  Legacy kubeconfig not found (this is expected with modern setup)"
+          fi
+          
+          # Legacy token secret check (not required in Kubernetes 1.24+)
+          if kubectl get secret insights-ros-ingress-token -n ${{ env.NAMESPACE }} >/dev/null 2>&1; then
+            echo "ℹ️  Legacy token secret found (unusual in Kubernetes 1.24+)"
+          else
+            echo "ℹ️  Legacy token secret not found (this is expected in Kubernetes 1.24+)"
+          fi
+
+          echo "=== Pod Readiness Check ==="
           # Wait for all pods to be in Running state
           timeout 600 bash -c "until kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/instance=${{ env.HELM_RELEASE_NAME }}' -n ${{ env.NAMESPACE }} --timeout=30s; do echo 'Waiting for pods...'; sleep 10; done"
 
@@ -196,10 +222,18 @@ jobs:
           echo "=== Authentication Status ==="
           echo "Service Accounts:"
           kubectl get serviceaccounts -n ${{ env.NAMESPACE }} || true
+          echo "Service Account Details:"
+          kubectl describe serviceaccount insights-ros-ingress -n ${{ env.NAMESPACE }} || true
           echo "Secrets:"
           kubectl get secrets -n ${{ env.NAMESPACE }} | grep -E "(insights-ros-ingress|token)" || true
+          echo "All Secrets:"
+          kubectl get secrets -n ${{ env.NAMESPACE }} || true
           echo "Authentication files:"
           ls -la /tmp/ | grep -E "(kubeconfig|auth)" || true
+          echo "Testing TokenRequest API:"
+          kubectl create token insights-ros-ingress -n ${{ env.NAMESPACE }} --duration=60s --dry-run=server || true
+          echo "RBAC Check:"
+          kubectl auth can-i get pods --as=system:serviceaccount:${{ env.NAMESPACE }}:insights-ros-ingress -n ${{ env.NAMESPACE }} || true
 
           echo "=== Ingress Service Logs ==="
           kubectl logs -n ${{ env.NAMESPACE }} -l app.kubernetes.io/name=ingress --tail=30 || true

--- a/ros-ocp/Chart.yaml
+++ b/ros-ocp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ros-ocp
 description: A Helm chart for ROS-OCP Backend services
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"
 
 keywords:

--- a/ros-ocp/templates/_helpers.tpl
+++ b/ros-ocp/templates/_helpers.tpl
@@ -545,3 +545,36 @@ Filesystem
     {{- end -}}
   {{- end -}}
 {{- end }}
+
+{{/*
+Cache service name (redis or valkey based on platform)
+*/}}
+{{- define "ros-ocp.cache.name" -}}
+{{- if eq (include "ros-ocp.isOpenShift" .) "true" -}}
+valkey
+{{- else -}}
+redis
+{{- end -}}
+{{- end }}
+
+{{/*
+Cache configuration (returns the appropriate config object)
+*/}}
+{{- define "ros-ocp.cache.config" -}}
+{{- if eq (include "ros-ocp.isOpenShift" .) "true" -}}
+{{- .Values.valkey | toYaml -}}
+{{- else -}}
+{{- .Values.redis | toYaml -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Cache CLI command (redis-cli or valkey-cli based on platform)
+*/}}
+{{- define "ros-ocp.cache.cli" -}}
+{{- if eq (include "ros-ocp.isOpenShift" .) "true" -}}
+valkey-cli
+{{- else -}}
+redis-cli
+{{- end -}}
+{{- end }}

--- a/ros-ocp/templates/deployment-redis.yaml
+++ b/ros-ocp/templates/deployment-redis.yaml
@@ -1,47 +1,73 @@
+{{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
+{{- $cacheName := ternary "valkey" "redis" $isOpenShift }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "ros-ocp.fullname" . }}-redis
+  name: {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: cache
-    app.kubernetes.io/name: redis
+    app.kubernetes.io/name: {{ $cacheName }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       {{- include "ros-ocp.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: cache
-      app.kubernetes.io/name: redis
+      app.kubernetes.io/name: {{ $cacheName }}
   template:
     metadata:
       labels:
         {{- include "ros-ocp.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: cache
-        app.kubernetes.io/name: redis
+        app.kubernetes.io/name: {{ $cacheName }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: redis
+        - name: {{ $cacheName }}
+          {{- if $isOpenShift }}
+          image: "{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}"
+          {{- else }}
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           ports:
-            - name: redis
+            - name: {{ $cacheName }}
+              {{- if $isOpenShift }}
+              containerPort: {{ .Values.valkey.port }}
+              {{- else }}
               containerPort: {{ .Values.redis.port }}
+              {{- end }}
               protocol: TCP
+          {{- if not $isOpenShift }}
           env:
             - name: REDIS_MAXMEMORY
               value: {{ .Values.redis.maxMemory | quote }}
             - name: REDIS_MAXMEMORY_POLICY
               value: {{ .Values.redis.maxMemoryPolicy | quote }}
+          {{- else }}
+          command:
+            - valkey-server
+          args:
+            - --bind
+            - "{{ .Values.valkey.bindAddress }}"
+            - --port
+            - "{{ .Values.valkey.port }}"
+            - --protected-mode
+            - "no"
+          {{- end }}
           livenessProbe:
             exec:
               command:
+                {{- if $isOpenShift }}
+                - valkey-cli
+                {{- else }}
                 - redis-cli
+                {{- end }}
                 - ping
             initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.periodSeconds }}
@@ -50,7 +76,11 @@ spec:
           readinessProbe:
             exec:
               command:
+                {{- if $isOpenShift }}
+                - valkey-cli
+                {{- else }}
                 - redis-cli
+                {{- end }}
                 - ping
             initialDelaySeconds: 5
             periodSeconds: {{ .Values.probes.periodSeconds }}

--- a/ros-ocp/templates/deployment-redis.yaml
+++ b/ros-ocp/templates/deployment-redis.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           ports:
             - name: {{ $cacheName }}
-              containerPort: {{ $cacheConfig.port }}
+              containerPort: 6379
               protocol: TCP
           {{- if not $isOpenShift }}
           env:
@@ -50,7 +50,7 @@ spec:
             - --bind
             - "{{ $cacheConfig.bindAddress }}"
             - --port
-            - "{{ $cacheConfig.port }}"
+            - "6379"
             - --protected-mode
             - "no"
           {{- end }}

--- a/ros-ocp/templates/deployment-redis.yaml
+++ b/ros-ocp/templates/deployment-redis.yaml
@@ -1,5 +1,7 @@
 {{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
-{{- $cacheName := ternary "valkey" "redis" $isOpenShift }}
+{{- $cacheName := include "ros-ocp.cache.name" . }}
+{{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
+{{- $cacheCliCommand := include "ros-ocp.cache.cli" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,19 +31,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ $cacheName }}
-          {{- if $isOpenShift }}
-          image: "{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
-          {{- end }}
+          image: "{{ $cacheConfig.image.repository }}:{{ $cacheConfig.image.tag }}"
           imagePullPolicy: {{ .Values.global.pullPolicy }}
           ports:
             - name: {{ $cacheName }}
-              {{- if $isOpenShift }}
-              containerPort: {{ .Values.valkey.port }}
-              {{- else }}
-              containerPort: {{ .Values.redis.port }}
-              {{- end }}
+              containerPort: {{ $cacheConfig.port }}
               protocol: TCP
           {{- if not $isOpenShift }}
           env:
@@ -54,20 +48,16 @@ spec:
             - valkey-server
           args:
             - --bind
-            - "{{ .Values.valkey.bindAddress }}"
+            - "{{ $cacheConfig.bindAddress }}"
             - --port
-            - "{{ .Values.valkey.port }}"
+            - "{{ $cacheConfig.port }}"
             - --protected-mode
             - "no"
           {{- end }}
           livenessProbe:
             exec:
               command:
-                {{- if $isOpenShift }}
-                - valkey-cli
-                {{- else }}
-                - redis-cli
-                {{- end }}
+                - {{ $cacheCliCommand }}
                 - ping
             initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.periodSeconds }}
@@ -76,11 +66,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                {{- if $isOpenShift }}
-                - valkey-cli
-                {{- else }}
-                - redis-cli
-                {{- end }}
+                - {{ $cacheCliCommand }}
                 - ping
             initialDelaySeconds: 5
             periodSeconds: {{ .Values.probes.periodSeconds }}

--- a/ros-ocp/templates/deployment-sources-api.yaml
+++ b/ros-ocp/templates/deployment-sources-api.yaml
@@ -1,6 +1,5 @@
 {{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
 {{- $cacheName := include "ros-ocp.cache.name" . }}
-{{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,8 +57,8 @@ spec:
           command: ['bash', '-c']
           args:
             - |
-              echo "Waiting for {{ $cacheName | title }} at {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}:{{ $cacheConfig.port }}..."
-              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-{{ $cacheName }}/{{ $cacheConfig.port }}" 2>/dev/null; do
+              echo "Waiting for {{ $cacheName | title }} at {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}:6379..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-{{ $cacheName }}/6379" 2>/dev/null; do
                 echo "{{ $cacheName | title }} not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
@@ -92,7 +91,7 @@ spec:
             - name: REDIS_CACHE_HOST
               value: {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}
             - name: REDIS_CACHE_PORT
-              value: {{ $cacheConfig.port | quote }}
+              value: "6379"
             - name: BYPASS_RBAC
               value: {{ .Values.sourcesApi.bypassRbac | quote }}
             - name: QUEUE_HOST

--- a/ros-ocp/templates/deployment-sources-api.yaml
+++ b/ros-ocp/templates/deployment-sources-api.yaml
@@ -1,5 +1,5 @@
 {{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
-{{- $cacheName := ternary "valkey" "redis" $isOpenShift }}
+{{- $cacheName := include "ros-ocp.cache.name" . }}
 {{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
 apiVersion: apps/v1
 kind: Deployment

--- a/ros-ocp/templates/deployment-sources-api.yaml
+++ b/ros-ocp/templates/deployment-sources-api.yaml
@@ -1,3 +1,6 @@
+{{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
+{{- $cacheName := ternary "valkey" "redis" $isOpenShift }}
+{{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,18 +53,18 @@ spec:
               done
               echo "Kafka is ready"
               echo "Kafka is ready"
-        - name: wait-for-redis
+        - name: wait-for-{{ $cacheName }}
           image: "{{ .Values.global.initContainers.waitFor.repository }}:{{ .Values.global.initContainers.waitFor.tag }}"
           command: ['bash', '-c']
           args:
             - |
-              echo "Waiting for Redis at {{ include "ros-ocp.fullname" . }}-redis:{{ .Values.redis.port }}..."
-              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-redis/{{ .Values.redis.port }}" 2>/dev/null; do
-                echo "Redis not ready yet, retrying in 5 seconds..."
+              echo "Waiting for {{ $cacheName | title }} at {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}:{{ $cacheConfig.port }}..."
+              until timeout 3 bash -c "echo > /dev/tcp/{{ include "ros-ocp.fullname" . }}-{{ $cacheName }}/{{ $cacheConfig.port }}" 2>/dev/null; do
+                echo "{{ $cacheName | title }} not ready yet, retrying in 5 seconds..."
                 sleep 5
               done
-              echo "Redis is ready"
-              echo "Redis is ready"
+              echo "{{ $cacheName | title }} is ready"
+              echo "{{ $cacheName | title }} is ready"
       containers:
         - name: sources-api
           image: "{{ .Values.sourcesApi.image.repository }}:{{ .Values.sourcesApi.image.tag }}"
@@ -87,9 +90,9 @@ spec:
             - name: LOG_LEVEL
               value: {{ .Values.sourcesApi.logLevel | quote }}
             - name: REDIS_CACHE_HOST
-              value: {{ include "ros-ocp.fullname" . }}-redis
+              value: {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}
             - name: REDIS_CACHE_PORT
-              value: {{ .Values.redis.port | quote }}
+              value: {{ $cacheConfig.port | quote }}
             - name: BYPASS_RBAC
               value: {{ .Values.sourcesApi.bypassRbac | quote }}
             - name: QUEUE_HOST

--- a/ros-ocp/templates/service-redis.yaml
+++ b/ros-ocp/templates/service-redis.yaml
@@ -1,5 +1,5 @@
 {{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
-{{- $cacheName := ternary "valkey" "redis" $isOpenShift }}
+{{- $cacheName := include "ros-ocp.cache.name" . }}
 {{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
 apiVersion: v1
 kind: Service

--- a/ros-ocp/templates/service-redis.yaml
+++ b/ros-ocp/templates/service-redis.yaml
@@ -1,20 +1,23 @@
+{{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
+{{- $cacheName := ternary "valkey" "redis" $isOpenShift }}
+{{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ros-ocp.fullname" . }}-redis
+  name: {{ include "ros-ocp.fullname" . }}-{{ $cacheName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "ros-ocp.labels" . | nindent 4 }}
     app.kubernetes.io/component: cache
-    app.kubernetes.io/name: redis
+    app.kubernetes.io/name: {{ $cacheName }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.redis.port }}
-      targetPort: redis
+    - port: {{ $cacheConfig.port }}
+      targetPort: {{ $cacheName }}
       protocol: TCP
-      name: redis
+      name: {{ $cacheName }}
   selector:
     {{- include "ros-ocp.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: cache
-    app.kubernetes.io/name: redis
+    app.kubernetes.io/name: {{ $cacheName }}

--- a/ros-ocp/templates/service-redis.yaml
+++ b/ros-ocp/templates/service-redis.yaml
@@ -1,6 +1,5 @@
 {{- $isOpenShift := eq (include "ros-ocp.isOpenShift" .) "true" }}
 {{- $cacheName := include "ros-ocp.cache.name" . }}
-{{- $cacheConfig := ternary .Values.valkey .Values.redis $isOpenShift }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,7 +12,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ $cacheConfig.port }}
+    - port: 6379
       targetPort: {{ $cacheName }}
       protocol: TCP
       name: {{ $cacheName }}

--- a/ros-ocp/values.yaml
+++ b/ros-ocp/values.yaml
@@ -88,13 +88,22 @@ kafka:
       size: 10Gi
     port: 29092
 
-# Redis
+# Redis (Development Cache - for Kubernetes deployments)
 redis:
   image:
     repository: quay.io/insights-onprem/redis-ephemeral
     tag: "6"
   maxMemory: 512mb
   maxMemoryPolicy: allkeys-lru
+  port: 6379
+
+# Valkey (Production Cache - for OpenShift deployments)
+valkey:
+  image:
+    # Primary image (Red Hat)
+    repository: registry.redhat.io/rhel10/valkey-8
+    tag: "latest"
+  bindAddress: "0.0.0.0"
   port: 6379
 
 # MinIO

--- a/ros-ocp/values.yaml
+++ b/ros-ocp/values.yaml
@@ -95,7 +95,6 @@ redis:
     tag: "6"
   maxMemory: 512mb
   maxMemoryPolicy: allkeys-lru
-  port: 6379
 
 # Valkey (Production Cache - for OpenShift deployments)
 valkey:
@@ -104,7 +103,6 @@ valkey:
     repository: registry.redhat.io/rhel10/valkey-8
     tag: "latest"
   bindAddress: "0.0.0.0"
-  port: 6379
 
 # MinIO
 minio:


### PR DESCRIPTION
Enable platform-aware cache deployment using Valkey on OpenShift and Redis on Kubernetes.

Update service discovery to dynamically connect to the appropriate cache backend based on platform detection.